### PR TITLE
Fix lagLength calculation

### DIFF
--- a/src/main/java/com/malt/mongopostgresqlstreamer/monitoring/Lag.java
+++ b/src/main/java/com/malt/mongopostgresqlstreamer/monitoring/Lag.java
@@ -21,6 +21,6 @@ class Lag {
     Lag(BsonTimestamp checkpoint) {
         lastCheckpoint = new Date(((long)checkpoint.getTime())*1000);
         now = new Date();
-        lagLength = now.getTime() - checkpoint.getTime();
+        lagLength = now.getTime() - lastCheckpoint.getTime();
     }
 }


### PR DESCRIPTION
`checkpoint.getTime()` was only giving seconds thus the lagLength was not getting calculated correctly